### PR TITLE
chore: add Dockerfile to prep for Actions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:10
+
+ENV PATH=$PATH:/app/node_modules/.bin
+WORKDIR /app
+COPY . .
+RUN npm install --production
+
+ENTRYPOINT ["probot", "receive"]
+CMD ["/lib/index.js"]


### PR DESCRIPTION
Adds a Dockerfile per [Probot docs](https://probot.github.io/docs/deployment/#github-actions) to prepare for Archaeologist's eventual port to GitHub Actions.

/cc @MarshallOfSound 