### PR TITLE
add initial scripts for actions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:8.15-jessie
+
+COPY . /usr/src/archaelogist
+
+CMD ["/usr/src/archaelogist/action.sh"]

--- a/action.sh
+++ b/action.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+mkdir -p artifacts
+
+export BASE_BRANCH=$(git show-branch | grep '*' | grep -v "$(git rev-parse --abbrev-ref HEAD)" | head -n1 | sed 's/.*\[\(.*\)\].*/\1/' | sed 's/[\^~].*//')
+
+if [[ -z "$BASE_BRANCH" ]]; then
+	# We are likely already on the master branch.
+	BASE_BRANCH=master
+fi
+
+git merge-base origin/$BASE_BRANCH HEAD > .dig-old
+
+rm -rf node_modules && npm install
+
+echo "#!/usr/bin/env node\nglobal.x=1" > node_modules/typescript/bin/tsc
+
+node node_modules/.bin/electron-docs-linter docs --outfile=electron-api.json --version=0.0.0-archaeologist.0
+
+node node_modules/.bin/electron-typescript-definitions docs --in=electron-api.json --out=artifacts/electron.new.d.ts
+
+git checkout .
+
+git checkout $(cat .dig-old)
+
+rm -rf node_modules && npm install
+
+echo "#!/usr/bin/env node\nglobal.x=1" > node_modules/typescript/bin/tsc
+
+node node_modules/.bin/electron-docs-linter docs --outfile=electron-api.json --version=0.0.0-archaeologist.0
+
+node node_modules/.bin/electron-typescript-definitions docs --in=electron-api.json --out=artifacts/electron.old.d.ts
+
+mv .dig-old artifacts
+
+our_diff=$(diff artifacts/*)
+if [[ "$our_diff" != "" ]]; then
+	echo "DIFF CHECK FAILED: Update the typescript file."
+	exit 1
+else
+	echo "DIFF CHECK PASSED: All files up to date."
+fi


### PR DESCRIPTION
Then this could be added in a workflow file like the following:

```
workflow "run archaeologist" {
    on = "push"
    resolves = ["archaeologist"]
}

action "archaeologist" {
    uses = "electron/archaeologist@master"
}
```

Unfortunately it won't work yet on actual push and pull_request events until they turn on that functionality but this is for now...

cc @codebytere