### PR TITLE
build: use a Node 10 image on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,15 +2,15 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:8.11
-    
+      - image: circleci/node:10.19
+
     working_directory: ~/repo
 
     steps:
       - checkout
   dig:
     docker:
-      - image: circleci/node:8.11
+      - image: circleci/node:10.19
 
     working_directory: ~/electron
 
@@ -43,7 +43,7 @@ jobs:
             else
               node node_modules/.bin/electron-docs-linter docs --outfile=electron-api.json --version=0.0.0-archaeologist.0
             fi
-      
+
       - run:
           command: |
             if [ -f "node_modules/.bin/electron-docs-parser" ]; then
@@ -75,7 +75,7 @@ jobs:
             else
               node node_modules/.bin/electron-docs-linter docs --outfile=electron-api.json --version=0.0.0-archaeologist.0
             fi
-      
+
       - run:
           command: |
             if [ -f "node_modules/.bin/electron-docs-parser" ]; then
@@ -89,4 +89,4 @@ jobs:
 
       - store_artifacts:
           path: artifacts
-      
+


### PR DESCRIPTION
Node 8 is past EOL, and I'm trying to add a devDependency to Electron that requires a recent version of Node 10.