### PR TITLE
"fix: zulassen, dass circleci-API-Aufrufe fehlschlagen und zurückgesetzt werden, um den Vorgang erneut zu versuchen, wenn dies geschieht"

### DIFF
--- a/src/circleci/artifacts.ts
+++ b/src/circleci/artifacts.ts
@@ -3,34 +3,15 @@ import fetch from 'node-fetch';
 import { IContext } from '../types';
 import { REPO_SLUG, CIRCLE_TOKEN } from './constants';
 
-const wait = (milliseconds: number) => new Promise<void>(r => setTimeout(r, milliseconds));
-
-export async function getCircleArtifacts (context: IContext, buildNumber: number, tryCount = 5) {
-  if (tryCount === 0) {
-    return {
-      missing: ['electron.new.d.ts', 'electron.old.d.ts', '.dig-old'],
-    };
-  }
-
+export async function getCircleArtifacts (context: IContext, buildNumber: number) {
   context.logger.info('fetching all artifacts for build:', `${buildNumber}`);
   const response = await fetch(
     `https://circleci.com/api/v1.1/project/github/${REPO_SLUG}/${buildNumber}/artifacts?circle-token=${CIRCLE_TOKEN}`
   );
-  if (response.status !== 200) {
-    context.logger.error('failed to fetch artifacts for build:', `${buildNumber}`, 'backing off and retrying in a bit', `(${tryCount} more attempts)`);
-    await wait(10000);
-    return getCircleArtifacts(context, buildNumber, tryCount - 1);
-  }
-
   const artifactList = await response.json();
   const missing: string[] = [];
 
-  async function getArtifact (name: string, tryCount = 5) {
-    if (tryCount === 0) {
-      missing.push(name);
-      return null;
-    }
-
+  async function getArtifact (name: string) {
     context.logger.info(`fetching artifact "${name}" for build:`, `${buildNumber}`);
     const circleArtifact = artifactList.find(artifact => artifact.path.endsWith(name));
     if (!circleArtifact) {
@@ -39,11 +20,6 @@ export async function getCircleArtifacts (context: IContext, buildNumber: number
     }
 
     const contentResponse = await fetch(`${circleArtifact.url}?circle-token=${CIRCLE_TOKEN}`);
-    if (contentResponse.status !== 200) {
-      context.logger.error('failed to fetch artifact', `"${circleArtifact.path}"`, 'from build', `"${buildNumber}"`, 'backing off and retrying in a bit', `(${tryCount} more attempts)`)
-      await wait(10000);
-      return getArtifact(name, tryCount - 1)
-    }
     return await contentResponse.text();
   }
 


### PR DESCRIPTION
Reverts electron/archaeologist#13