### PR TITLE
ci: bump to Node.js 20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,14 +37,14 @@ commands:
 jobs:
   build:
     docker:
-      - image: cimg/node:16.15
+      - image: cimg/node:20.13
     working_directory: ~/repo
     steps:
       - checkout
 
   dig:
     docker:
-      - image: cimg/node:16.15
+      - image: cimg/node:20.13
     working_directory: ~/electron
     steps:
       - run:


### PR DESCRIPTION
It's using an EOL version at the moment, and blocks adding packages to `e/e` which need Node.js >= 18.