### PR TITLE
chore: resolve dependabot security alerts

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2515,15 +2515,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.4.3":
-  version: 7.5.10
-  resolution: "tar@npm:7.5.10"
+  version: 7.5.13
+  resolution: "tar@npm:7.5.13"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/ed905e4b33886377df6e9206e5d1bd34458c21666e27943f946799416f86348c938590d573d6a69312cb29c583b122647a64ec92782f2b7e24e68d985dd72531
+  checksum: 10c0/5c65b8084799bde7a791593a1c1a45d3d6ee98182e3700b24c247b7b8f8654df4191642abbdb07ff25043d45dcff35620827c3997b88ae6c12040f64bed5076b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Safe-only dependabot sweep — lockfile refresh within existing semver ranges.

| Package | Strategy | Version change |
| --- | --- | --- |
| `tar` | `yarn up -R` (transitive, in-range) | 7.5.10 → 7.5.13 |

### Flagged (not changed)

None.

### Verification

- `yarn install --immutable` passes
- `yarn npm audit --all --recursive --no-deprecations` → 0 advisories
- `npmMinimalAgeGate: 10080` respected (tar@7.5.13 published 2026-03-23)
